### PR TITLE
Fixing plot for compare_solutions_mplus

### DIFF
--- a/R/compare_solutions_mplus.R
+++ b/R/compare_solutions_mplus.R
@@ -8,7 +8,6 @@
 #' @param return_stats_df whether to return a list of fit statistics for the solutions explored; defaults to FALSE
 #' @inheritParams estimate_profiles_mplus
 #' @return a list with a data.frame with the BIC values and a list with all of the model output; if save_models is the name of an rds file (i.e., "out.rds"), then the model output will be written with that filename and only the data.frame will be returned
-#' @import mclust
 #' @importFrom dplyr %>%
 #' @examples
 #' \dontrun{
@@ -154,17 +153,14 @@ compare_solutions_mplus <- function(df, ...,
         print(dplyr::as_tibble(out_df))
         invisible(dplyr::as_tibble(out_df))
     } else {
-        p <- out_df %>%
-            tidyr::gather("key", "val", -.data$n_profiles) %>%
-            dplyr::filter(
-                .data$val != "Convergence problem",
-                .data$val != "LL not replicated"
-            ) %>%
-            dplyr::mutate(n_profiles = as.integer(.data$n_profiles)) %>%
-            ggplot2::ggplot(ggplot2::aes_string(x = "n_profiles", y = "val", shape = "key", color = "key", group = "key")) +
+        out_df %>%
+            tidyr::gather("Model", "BIC", -.data$n_profiles, convert = TRUE) %>%
+            dplyr::filter(stringr::str_detect(.data$BIC, "\\d+\\.*\\d*")) %>%
+            dplyr::mutate(BIC = as.numeric(.data$BIC),
+                          n_profiles = as.integer(.data$n_profiles),
+                          Model = stringr::str_extract(.data$Model, "\\d")) %>% 
+        ggplot2::ggplot(ggplot2::aes_string(x = "n_profiles", y = "BIC", shape = "Model", color = "Model", group = "Model")) +
             ggplot2::geom_line() +
             ggplot2::geom_point()
-        print(p)
-        invisible(p)
     }
 }

--- a/R/compare_solutions_mplus.R
+++ b/R/compare_solutions_mplus.R
@@ -154,7 +154,7 @@ compare_solutions_mplus <- function(df, ...,
         invisible(dplyr::as_tibble(out_df))
     } else {
         out_df %>%
-            tidyr::gather("Model", "BIC", -.data$n_profiles, convert = TRUE) %>%
+            tidyr::gather("Model", "BIC", -.data$n_profiles) %>%
             dplyr::filter(stringr::str_detect(.data$BIC, "\\d+\\.*\\d*")) %>%
             dplyr::mutate(BIC = as.numeric(.data$BIC),
                           n_profiles = as.integer(.data$n_profiles),

--- a/R/plot_profiles.R
+++ b/R/plot_profiles.R
@@ -94,7 +94,7 @@ plot_profiles <- function(x, to_center = F, to_scale = F, plot_what = "tibble", 
           data.frame(Variable = rownames(x$parameters$mean), x$parameters$mean)
       names(plotdat)[-1] <- paste0("Value.", 1:n_classes)
       plotdat <-
-          subset(reshape(
+          subset(stats::reshape(
               plotdat,
               direction = "long",
               varying = 2:ncol(plotdat),
@@ -111,7 +111,7 @@ plot_profiles <- function(x, to_center = F, to_scale = F, plot_what = "tibble", 
               paste0("Probability.", 1:n_classes)
           rawdata <-
               subset(
-                  reshape(
+                  stats::reshape(
                       rawdata,
                       direction = "long",
                       varying = 1:n_classes,
@@ -124,7 +124,7 @@ plot_profiles <- function(x, to_center = F, to_scale = F, plot_what = "tibble", 
           names(rawdata)[1:ncol(x$data)] <-
               paste0("Value.", gsub("\\.", "_", colnames(x$data)))
           rawdata <-
-              reshape(
+              stats::reshape(
                   rawdata,
                   direction = "long",
                   varying = 1:ncol(x$data),
@@ -136,11 +136,11 @@ plot_profiles <- function(x, to_center = F, to_scale = F, plot_what = "tibble", 
           classplot <- classplot + geom_point(
               data = rawdata,
               position = position_jitterdodge(jitter.width = .10),
-              aes(
-                  x = Class,
-                  y = Value,
-                  colour = Variable,
-                  alpha = Probability
+              aes_string(
+                  x = "Class",
+                  y = "Value",
+                  colour = "Variable",
+                  alpha = "Probability"
               )
           ) +
               scale_alpha_continuous(guide = FALSE, range = c(0, .1))
@@ -175,21 +175,21 @@ plot_profiles <- function(x, to_center = F, to_scale = F, plot_what = "tibble", 
           }
 
           ses <- data.frame(apply(bootstraps$mean, 3, function(class) {
-              apply(class, 2, quantile, probs = c((.5 * (1 - ci)), 1 - (.5 * (1 - ci))))
+              apply(class, 2, stats::quantile, probs = c((.5 * (1 - ci)), 1 - (.5 * (1 - ci))))
           }))
           names(ses) <- paste0("se.", 1:n_classes)
           ses$Variable <- unlist(lapply(colnames(x$data), rep, 2))
           ses$boundary <- "lower"
           ses$boundary[seq(2, nrow(ses), by = 2)] <- "upper"
           ses <-
-              reshape(
+              stats::reshape(
                   ses,
                   direction = "long",
                   varying = 1:n_classes,
                   timevar = "Class"
               )
           ses <-
-              reshape(
+              stats::reshape(
                   ses,
                   direction = "wide",
                   idvar = c("Variable", "Class"),
@@ -199,11 +199,11 @@ plot_profiles <- function(x, to_center = F, to_scale = F, plot_what = "tibble", 
           classplot <-
               classplot + geom_errorbar(
                   data = ses,
-                  aes(
-                      x = Class,
-                      colour = Variable,
-                      ymin = se.lower,
-                      ymax = se.upper
+                  aes_string(
+                      x = "Class",
+                      colour = "Variable",
+                      ymin = "se.lower",
+                      ymax = "se.upper"
                   ),
                   position = position_dodge(width = .75),
                   width = .4


### PR DESCRIPTION
The y-axis was coming in as a character. I changed the way the subsetting was happening to remove non-convergence warnings and converted the y-axis to be numeric. I also have a few other small suggested edits in there, like changing the y-axis label to BIC and the key label to be Models (with the models just being integers, rather than "model_1" ... "model_n". In the plot_profiles file I just made a few edits to get some R CMD Check warnings to go away (I was making sure my edits didn't break anything).

## Plot before edits (CRAN version)
<img width="589" alt="screen shot 2018-03-23 at 6 25 50 pm" src="https://user-images.githubusercontent.com/10944136/37858823-d86ff834-2ec7-11e8-91ca-6b3151836bf9.png">

## Plot with suggested edits
<img width="591" alt="screen shot 2018-03-23 at 6 24 32 pm" src="https://user-images.githubusercontent.com/10944136/37858834-edb5e49c-2ec7-11e8-91fb-1073c8823c82.png">


As an aside, I noticed this dev version is getting the following warning on load

> Warning: replacing previous import ‘dplyr::vars’ by ‘ggplot2::vars’ when loading ‘tidyLPA’

I'm pretty sure this is because you're loading the entire ggplot2 and dplyr libraries in your namespace. You could get around this by just importing the functions you're using in tidyLPA, using `importFrom()`.  

You probably know all this, but just an FYI if not. I'd be happy to help fix the name spacing issues throughout, if you'd like.

Thanks for the great package!