### PR TITLE
Changed LMR to VLMR in body of function

### DIFF
--- a/R/compare_solutions_mplus.R
+++ b/R/compare_solutions_mplus.R
@@ -63,7 +63,7 @@ compare_solutions_mplus <- function(df, ...,
                 st_iterations = st_iterations,
                 return_save_data = F,
                 n_processors = n_processors,
-                include_LMR = include_LMR,
+                include_VLMR = include_VLMR,
                 include_BLRT = include_BLRT,
                 remove_tmp_files = remove_tmp_files
             ))


### PR DESCRIPTION
It looks like in commit [03e243d](https://github.com/jrosen48/tidyLPA/commit/03e243dc3d0c03c9830f8ff0ccaddff4f288e493#diff-c5dc32a88633a6f1f8769e142e1e3c67) you updated the documentation to change `include_LMR` to `include_VLMR`, but missed the update in the body of the function. This PR fixes that (I only ran into it because I had to go back to some of my code and it wouldn't run because of this).