### PR TITLE
Add fitting indices to output tibble when calling estimate_profiles_mplus with return_save_data = TRUE

### DIFF
--- a/R/estimate_profiles_mplus.R
+++ b/R/estimate_profiles_mplus.R
@@ -110,7 +110,7 @@ estimate_profiles_mplus <- function(df,
     } else {
         ANALYSIS_line1b <- NULL
     }
-    ANALYSIS_line2 <- paste0("start = ", starts[1], " ", starts[2], ";")
+    ANALYSIS_line2 <- paste0("starts = ", starts[1], " ", starts[2], ";")
     ANALYSIS_line3 <- paste0("miterations = ", m_iterations, ";")
     ANALYSIS_line4 <- paste0("stiterations = ", st_iterations, ";")
     ANALYSIS_line5 <- paste0("convergence = ", convergence_criterion, ";")

--- a/R/estimate_profiles_mplus.R
+++ b/R/estimate_profiles_mplus.R
@@ -332,6 +332,13 @@ estimate_profiles_mplus <- function(df,
             file.remove(savedata_filename)
             file.remove("Mplus Run Models.log")
         }
+        fit_stats = c("LL","BIC","aBIC","AIC","Entropy")
+        fs = rep(NA,length(fit_stats))
+        names(fs) = fit_stats
+        available_fit_stats = intersect(names(m$summaries),fit_stats)
+        for (s in available_fit_stats)
+            fs[s] = m$summaries[,s]
+        attr(x,"fit_stats") = fs
         return(x)
 
     } else {

--- a/R/estimate_profiles_mplus.R
+++ b/R/estimate_profiles_mplus.R
@@ -132,14 +132,14 @@ estimate_profiles_mplus <- function(df,
     MODEL_overall_line2 <- paste0(unquoted_variable_name, ";")
 
     if (include_VLMR == TRUE) {
-        OUTPUT_line0 <- "OUTPUT: tech1 tech4 tech7 TECH11 tech14 tech12 tech13 sampstat svalues patterns residual stdyx;"
+        OUTPUT_line0 <- "OUTPUT: tech1 tech4 tech7 TECH11 tech14 tech12 sampstat svalues patterns residual stdyx;"
         if (include_BLRT == TRUE) {
-            OUTPUT_line0 <- "OUTPUT: tech1 tech4 tech7 tech11 tech14 tech12 tech13 sampstat svalues patterns residual stdyx TECH14;"
+            OUTPUT_line0 <- "OUTPUT: tech1 tech4 tech7 tech11 tech14 tech12 sampstat svalues patterns residual stdyx TECH14;"
         }
     } else {
-        OUTPUT_line0 <- "OUTPUT: tech1 tech4 tech7 tech14 tech12 tech13 sampstat svalues patterns residual stdyx;"
+        OUTPUT_line0 <- "OUTPUT: tech1 tech4 tech7 tech14 tech12 sampstat svalues patterns residual stdyx;"
         if (include_BLRT == TRUE) {
-            OUTPUT_line0 <- "OUTPUT: tech1 tech4 tech7 tech14 tech12 tech13 sampstat svalues patterns residual stdyx TECH14;"
+            OUTPUT_line0 <- "OUTPUT: tech1 tech4 tech7 tech14 tech12 sampstat svalues patterns residual stdyx TECH14;"
         }
     }
 
@@ -174,7 +174,7 @@ estimate_profiles_mplus <- function(df,
                 }
             }
         }
-    } else if (model == 2) {
+    } else if (model == 3) {
         overall_collector <- list()
         for (j in 1:length(var_list)) {
             for (k in j:length(var_list)) {
@@ -202,7 +202,7 @@ estimate_profiles_mplus <- function(df,
                 }
             }
         }
-    } else if (model == 3) {
+    } else if (model == 2) {
         overall_collector <- list()
         for (j in 1:length(var_list)) {
             for (k in j:length(var_list)) {
@@ -233,7 +233,7 @@ estimate_profiles_mplus <- function(df,
                 }
             }
         }
-    } else if (model == 4) {
+    } else if (model == 6) {
         overall_collector <- list()
         for (j in 1:length(var_list)) {
             for (k in j:length(var_list)) {

--- a/R/estimate_profiles_mplus.R
+++ b/R/estimate_profiles_mplus.R
@@ -221,9 +221,8 @@ estimate_profiles_mplus <- function(df,
 
     all_the_lines <- gsub('(.{1,90})(\\s|$)', '\\1\n', all_the_lines) # from this helpful SO answer: https://stackoverflow.com/questions/2351744/insert-line-breaks-in-long-string-word-wrap
 
-    write_lines(all_the_lines,
-        script_filename
-    )
+    cat(paste0(all_the_lines, collapse = ""),
+        file = script_filename)
 
     x <- capture.output(MplusAutomation::runModels(target = paste0(getwd(), "/", script_filename)))
     capture <- capture.output(m <- MplusAutomation::readModels(target = paste0(getwd(), "/", output_filename)))

--- a/R/estimate_profiles_mplus.R
+++ b/R/estimate_profiles_mplus.R
@@ -39,7 +39,7 @@ estimate_profiles_mplus <- function(df,
                                     output_filename = "i.out",
                                     savedata_filename = "d-mod.dat",
                                     model = 1,
-                                    starts = c(20, 4),
+                                    starts = c(100, 10),
                                     m_iterations = 500,
                                     st_iterations = 10,
                                     convergence_criterion = 1E-6,
@@ -86,8 +86,13 @@ estimate_profiles_mplus <- function(df,
     for (i in seq_along(names(d))) {
         var_list[[i]] <- names(d)[i]
     }
-
-    TITLE <- paste0("TITLE: ", the_title)
+    titles = c("Equal variances, and covariances fixed to 0 (model 1)",
+               "Equal variances, and equal covariances (model 2)",
+               "Varying variances, and covariances fixed to 0 (model 3)",
+               "Varying variances, and equal covariances (model 4)",
+               "Equal variances, and varying covariances (model 5)",
+               "Varying variances, and varying covariances (model 6)")
+    TITLE <- paste0("TITLE: ", titles[model])
 
     DATA <- paste0("DATA: File is ", data_filename, ";")
 
@@ -170,15 +175,32 @@ estimate_profiles_mplus <- function(df,
                                  make_class_mplus(var_list,class_number = i,fix_variances = T),
                                  covariances_mplus(var_list,
                                                  estimate_covariance = T,
-                                                 param_counter = length(varlist)))
-
+                                                 param_counter = length(var_list)))
+        }
+    } else if (model == 4) { # Varying means, varying variances, and equal covariances
+        overall_collector <- covariances_mplus(var_list, estimate_covariance = T)
+        class_collector <- list()
+        for (i in 1:n_profiles) {
+            class_collector <- c(class_collector,
+                                 make_class_mplus(var_list,class_number = i,fix_variances = F),
+                                 covariances_mplus(var_list,
+                                                   estimate_covariance = T,
+                                                   param_counter = 0))
+        }
+    } else if (model == 5) { # Varying means, equal variances, and varying covariances
+        overall_collector <- covariances_mplus(var_list, estimate_covariance = T)
+        class_collector <- list()
+        for (i in 1:n_profiles) {
+            class_collector <- c(class_collector,
+                                 make_class_mplus(var_list,class_number = i,fix_variances = T),
+                                 covariances_mplus(var_list, estimate_covariance = T))
         }
     } else if (model == 6) { # Varying means, varying variances, and varying covariances
         overall_collector <- covariances_mplus(var_list, estimate_covariance = T)
         class_collector <- list()
         for (i in 1:n_profiles) {
             class_collector <- c(class_collector,
-                                 make_class_mplus(var_list,class_number = 1,fix_variances = F),
+                                 make_class_mplus(var_list,class_number = i,fix_variances = F),
                                  covariances_mplus(var_list, estimate_covariance = T))
         }
     }

--- a/R/estimate_profiles_mplus.R
+++ b/R/estimate_profiles_mplus.R
@@ -146,79 +146,40 @@ estimate_profiles_mplus <- function(df,
     SAVEDATA_line0 <- paste0("SAVEDATA: File is ", savedata_filename, ";")
     SAVEDATA_line1 <- "SAVE = CPROBABILITIES;"
 
-    if (model == 1) {
-        overall_collector <- variances_mplus(var_list, estimate_variance = F)
-        the_index <- 0
+    if (model == 1) { # Varying means, equal variances, and covariances fixed to 0
+        overall_collector <- covariances_mplus(var_list, estimate_covariance = F)
         class_collector <- list()
         for (i in 1:n_profiles) {
-            if (the_index != 0) {
-                the_index <- the_index + 1
-            }
-            class_collector[[the_index + 1]] <- paste0("%c#", i, "%")
-            class_collector[[the_index + 2]] <- paste0("[", unquoted_variable_name, "];")
-            class_collector[[the_index + 3]] <- paste0(unquoted_variable_name, "(", 1, "-", length(var_list), ");")
-            class_collector = c(class_collector,
-                                variances_mplus(var_list, estimate_variance = F))
+            class_collector <- c(class_collector,
+                                 make_class_mplus(var_list,class_number = i,fix_variances = T),
+                                 covariances_mplus(var_list, estimate_covariance = F))
         }
-    } else if (model == 3) {
-        overall_collector <- variances_mplus(var_list, estimate_variance = F)
-        the_index <- 0
+    } else if (model == 3) { # Varying means, varying variances, and covariances fixed to 0
+        overall_collector <- covariances_mplus(var_list, estimate_covariance = F)
         class_collector <- list()
         for (i in 1:n_profiles) {
-            if (the_index != 0) {
-                the_index <- the_index + 1
-            }
-            class_collector[[the_index + 1]] <- paste0("%c#", i, "%")
-            class_collector[[the_index + 2]] <- paste0("[", unquoted_variable_name, "];")
-            class_collector[[the_index + 3]] <- paste0(unquoted_variable_name, ";")
-            class_collector = c(class_collector,
-                                variances_mplus(var_list, estimate_variance = F))
+            class_collector <- c(class_collector,
+                                 make_class_mplus(var_list,class_number = i,fix_variances = F),
+                                 covariances_mplus(var_list, estimate_covariance = F))
         }
-    } else if (model == 2) {
-        overall_collector <- variances_mplus(var_list, estimate_variance = T)
-        the_index <- 0
+    } else if (model == 2) { # Varying means, equal variances, and equal covariances
+        overall_collector <- covariances_mplus(var_list, estimate_covariance = T)
         class_collector <- list()
         for (i in 1:n_profiles) {
-            if (the_index != 0) {
-                the_index <- the_index + 1
-            }
-            class_collector[[the_index + 1]] <- paste0("%c#", i, "%")
-            class_collector[[the_index + 2]] <- paste0("[", unquoted_variable_name, "];")
-            class_collector[[the_index + 3]] <- paste0(unquoted_variable_name, "(", 1, "-", length(var_list), ");")
+            class_collector <- c(class_collector,
+                                 make_class_mplus(var_list,class_number = i,fix_variances = T),
+                                 covariances_mplus(var_list,
+                                                 estimate_covariance = T,
+                                                 param_counter = length(varlist)))
 
-            temp_index <- 0
-            for (j in 1:length(var_list)) {
-                for (k in j:length(var_list)) {
-                    if (var_list[[j]] != var_list[[k]]) {
-                        the_index <- length(class_collector)
-                        class_collector[[the_index + 1]] <- paste0(var_list[[j]], " WITH ", var_list[[k]], "(", length(var_list) + temp_index + 1, ");")
-                        temp_index <- (temp_index + 1)
-                    }
-                }
-            }
         }
-    } else if (model == 6) {
-        overall_collector <- variances_mplus(var_list, estimate_variance = T)
-        the_index <- 0
+    } else if (model == 6) { # Varying means, varying variances, and varying covariances
+        overall_collector <- covariances_mplus(var_list, estimate_covariance = T)
         class_collector <- list()
         for (i in 1:n_profiles) {
-            if (the_index != 0) {
-                the_index <- the_index + 1
-            }
-            class_collector[[the_index + 1]] <- paste0("%c#", i, "%")
-            class_collector[[the_index + 2]] <- paste0("[", unquoted_variable_name, "];")
-            class_collector[[the_index + 3]] <- paste0(unquoted_variable_name, ";")
-
-            temp_index <- 0
-            for (j in 1:length(var_list)) {
-                for (k in j:length(var_list)) {
-                    if (var_list[[j]] != var_list[[k]]) {
-                        the_index <- length(class_collector)
-                        class_collector[[the_index + 1]] <- paste0(var_list[[j]], " WITH ", var_list[[k]], ";")
-                        temp_index <- (temp_index + 1)
-                    }
-                }
-            }
+            class_collector <- c(class_collector,
+                                 make_class_mplus(var_list,class_number = 1,fix_variances = F),
+                                 covariances_mplus(var_list, estimate_covariance = T))
         }
     }
 

--- a/R/estimate_profiles_mplus.R
+++ b/R/estimate_profiles_mplus.R
@@ -147,15 +147,7 @@ estimate_profiles_mplus <- function(df,
     SAVEDATA_line1 <- "SAVE = CPROBABILITIES;"
 
     if (model == 1) {
-        overall_collector <- list()
-        for (j in 1:length(var_list)) {
-            for (k in j:length(var_list)) {
-                if (var_list[[j]] != var_list[[k]]) {
-                    the_index <- length(overall_collector)
-                    overall_collector[[the_index + 1]] <- paste0(var_list[[j]], " WITH ", var_list[[k]], "@0;")
-                }
-            }
-        }
+        overall_collector <- variances_mplus(var_list, estimate_variance = F)
         the_index <- 0
         class_collector <- list()
         for (i in 1:n_profiles) {
@@ -175,15 +167,7 @@ estimate_profiles_mplus <- function(df,
             }
         }
     } else if (model == 3) {
-        overall_collector <- list()
-        for (j in 1:length(var_list)) {
-            for (k in j:length(var_list)) {
-                if (var_list[[j]] != var_list[[k]]) {
-                    the_index <- length(overall_collector)
-                    overall_collector[[the_index + 1]] <- paste0(var_list[[j]], " WITH ", var_list[[k]], "@0;")
-                }
-            }
-        }
+        overall_collector <- variances_mplus(var_list, estimate_variance = F)
         the_index <- 0
         class_collector <- list()
         for (i in 1:n_profiles) {
@@ -203,15 +187,7 @@ estimate_profiles_mplus <- function(df,
             }
         }
     } else if (model == 2) {
-        overall_collector <- list()
-        for (j in 1:length(var_list)) {
-            for (k in j:length(var_list)) {
-                if (var_list[[j]] != var_list[[k]]) {
-                    the_index <- length(overall_collector)
-                    overall_collector[[the_index + 1]] <- paste0(var_list[[j]], " WITH ", var_list[[k]], ";")
-                }
-            }
-        }
+        overall_collector <- variances_mplus(var_list, estimate_variance = T)
         the_index <- 0
         class_collector <- list()
         for (i in 1:n_profiles) {
@@ -234,15 +210,7 @@ estimate_profiles_mplus <- function(df,
             }
         }
     } else if (model == 6) {
-        overall_collector <- list()
-        for (j in 1:length(var_list)) {
-            for (k in j:length(var_list)) {
-                if (var_list[[j]] != var_list[[k]]) {
-                    the_index <- length(overall_collector)
-                    overall_collector[[the_index + 1]] <- paste0(var_list[[j]], " WITH ", var_list[[k]], ";")
-                }
-            }
-        }
+        overall_collector <- variances_mplus(var_list, estimate_variance = T)
         the_index <- 0
         class_collector <- list()
         for (i in 1:n_profiles) {

--- a/R/estimate_profiles_mplus.R
+++ b/R/estimate_profiles_mplus.R
@@ -339,6 +339,8 @@ estimate_profiles_mplus <- function(df,
         for (s in available_fit_stats)
             fs[s] = m$summaries[,s]
         attr(x,"fit_stats") = fs
+        attr(x,"mplus_warnings") = m$warnings
+        attr(x,"mplus_errors") = m$errors
         return(x)
 
     } else {

--- a/R/estimate_profiles_mplus.R
+++ b/R/estimate_profiles_mplus.R
@@ -157,14 +157,8 @@ estimate_profiles_mplus <- function(df,
             class_collector[[the_index + 1]] <- paste0("%c#", i, "%")
             class_collector[[the_index + 2]] <- paste0("[", unquoted_variable_name, "];")
             class_collector[[the_index + 3]] <- paste0(unquoted_variable_name, "(", 1, "-", length(var_list), ");")
-            for (j in 1:length(var_list)) {
-                for (k in j:length(var_list)) {
-                    if (var_list[[j]] != var_list[[k]]) {
-                        the_index <- length(class_collector)
-                        class_collector[[the_index + 1]] <- paste0(var_list[[j]], " WITH ", var_list[[k]], "@0;")
-                    }
-                }
-            }
+            class_collector = c(class_collector,
+                                variances_mplus(var_list, estimate_variance = F))
         }
     } else if (model == 3) {
         overall_collector <- variances_mplus(var_list, estimate_variance = F)
@@ -177,14 +171,8 @@ estimate_profiles_mplus <- function(df,
             class_collector[[the_index + 1]] <- paste0("%c#", i, "%")
             class_collector[[the_index + 2]] <- paste0("[", unquoted_variable_name, "];")
             class_collector[[the_index + 3]] <- paste0(unquoted_variable_name, ";")
-            for (j in 1:length(var_list)) {
-                for (k in j:length(var_list)) {
-                    if (var_list[[j]] != var_list[[k]]) {
-                        the_index <- length(class_collector)
-                        class_collector[[the_index + 1]] <- paste0(var_list[[j]], " WITH ", var_list[[k]], "@0;")
-                    }
-                }
-            }
+            class_collector = c(class_collector,
+                                variances_mplus(var_list, estimate_variance = F))
         }
     } else if (model == 2) {
         overall_collector <- variances_mplus(var_list, estimate_variance = T)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -128,18 +128,33 @@ write_mplus <- function(d, file_name, na_string = "-999", ...) {
 	            ...)
 }
 
-variances_mplus = function(var_list, estimate_variance = F) {
-    variances <- list()
-    for (j in 1:length(var_list)) {
-        for (k in j:length(var_list)) {
-            if (var_list[[j]] != var_list[[k]]) {
-                the_index <- length(variances)
-                variances[[the_index + 1]] <- paste0(var_list[[j]],
-                                                             " WITH ",
-                                                             var_list[[k]],
-                                                             ifelse(estimate_variance,"","@0"),";")
-            }
-        }
+make_class_mplus = function(var_list,class_number, fix_variances = F) {
+
+    class_init <- vector(length = 3, mode = "list")
+    class_init[[1]] <- paste0("%c#", class_number, "%")
+    class_init[[2]] <- paste0("[",paste(var_list, collapse = " "),"];")
+    class_init[[3]] <- paste0(paste(var_list, collapse = " "),
+                              ifelse(fix_variances,
+                                     paste0("(1-",length(var_list),")"),
+                                     ""),
+                              ";")
+    return(class_init)
+}
+
+covariances_mplus = function(var_list, estimate_covariance = F, param_counter = NULL) {
+
+    combine2 <- combn(length(var_list),2)
+    variances <- vector(length = ncol(combine2), mode = "list")
+
+    for (k in 1:ncol(combine2)) {
+        variances[[k]] <- paste0(var_list[[combine2[1,k]]],
+                                 " WITH ",
+                                 var_list[[combine2[2,k]]],
+                                 ifelse(estimate_covariance,"","@0"),
+                                 ifelse(is.null(param_counter),
+                                        "",
+                                        paste0(" (",param_counter+k,")")),
+                                 ";")
     }
     return(variances)
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -158,3 +158,11 @@ covariances_mplus = function(var_list, estimate_covariance = F, param_counter = 
     }
     return(variances)
 }
+
+
+get_fit_stat = function(m,stat) {
+    return(ifelse(stat %in% names(m$summaries),
+                  m$summaries[[stat]],
+                  NA)
+    )
+}

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -127,3 +127,19 @@ write_mplus <- function(d, file_name, na_string = "-999", ...) {
 	            na = as.character(na_string),
 	            ...)
 }
+
+variances_mplus = function(var_list, estimate_variance = F) {
+    variances <- list()
+    for (j in 1:length(var_list)) {
+        for (k in j:length(var_list)) {
+            if (var_list[[j]] != var_list[[k]]) {
+                the_index <- length(variances)
+                variances[[the_index + 1]] <- paste0(var_list[[j]],
+                                                             " WITH ",
+                                                             var_list[[k]],
+                                                             ifelse(estimate_variance,"","@0"),";")
+            }
+        }
+    }
+    return(variances)
+}


### PR DESCRIPTION
Until now, estimate_profiles_mplus returns only a tibble with class probabilities when return_save_data = TRUE.
With this PR, fit indeces (LL, BIC, aBIC, AIC, Entropy) are added as attributes to the tibble, as are mplus warnings and error messages.

To get these attributes, R's attr function can be used as follows:
````
my_lpa = estimate_profiles_mplus(..., return_save_data = TRUE )
fit_indices = attr(my_lpa,"fit_indices")
mplus_warnings= attr(my_lpa,"mplus_warnings")
mplus_errors= attr(my_lpa,"mplus_errors")
```